### PR TITLE
Fix: CentOS 7 compatibility

### DIFF
--- a/.github/workflows/encrypt_private_keys.yml
+++ b/.github/workflows/encrypt_private_keys.yml
@@ -55,6 +55,14 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
+    - name: Build the collection
+      run: |
+        collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
+        echo "::set-env name=COLLECTION_FILE::$collection_file"
+
+    - name: Install the collection
+      run: ansible-galaxy collection install $COLLECTION_FILE
+
     - name: Run tests
       working-directory: ansible_collections/klusters/tls
       run: |

--- a/.github/workflows/encrypt_private_keys.yml
+++ b/.github/workflows/encrypt_private_keys.yml
@@ -56,11 +56,13 @@ jobs:
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
     - name: Build the collection
+      working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
         echo "::set-env name=COLLECTION_FILE::$collection_file"
 
     - name: Install the collection
+      working-directory: ansible_collections/klusters/tls
       run: ansible-galaxy collection install $COLLECTION_FILE
 
     - name: Run tests

--- a/.github/workflows/encrypt_private_keys.yml
+++ b/.github/workflows/encrypt_private_keys.yml
@@ -55,15 +55,11 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
-    - name: Build the collection
+    - name: Build and Install the collection
       working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-        echo "::set-env name=COLLECTION_FILE::$collection_file"
-
-    - name: Install the collection
-      working-directory: ansible_collections/klusters/tls
-      run: ansible-galaxy collection install $COLLECTION_FILE
+        ansible-galaxy collection install $collection_file
 
     - name: Run tests
       working-directory: ansible_collections/klusters/tls

--- a/.github/workflows/keystores.yml
+++ b/.github/workflows/keystores.yml
@@ -55,6 +55,14 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
+    - name: Build the collection
+      run: |
+        collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
+        echo "::set-env name=COLLECTION_FILE::$collection_file"
+
+    - name: Install the collection
+      run: ansible-galaxy collection install $COLLECTION_FILE
+
     - name: Run tests
       working-directory: ansible_collections/klusters/tls
       run: |

--- a/.github/workflows/keystores.yml
+++ b/.github/workflows/keystores.yml
@@ -56,11 +56,13 @@ jobs:
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
     - name: Build the collection
+      working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
         echo "::set-env name=COLLECTION_FILE::$collection_file"
 
     - name: Install the collection
+      working-directory: ansible_collections/klusters/tls
       run: ansible-galaxy collection install $COLLECTION_FILE
 
     - name: Run tests

--- a/.github/workflows/keystores.yml
+++ b/.github/workflows/keystores.yml
@@ -55,15 +55,11 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
-    - name: Build the collection
+    - name: Build and Install the collection
       working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-        echo "::set-env name=COLLECTION_FILE::$collection_file"
-
-    - name: Install the collection
-      working-directory: ansible_collections/klusters/tls
-      run: ansible-galaxy collection install $COLLECTION_FILE
+        ansible-galaxy collection install $collection_file
 
     - name: Run tests
       working-directory: ansible_collections/klusters/tls

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -55,6 +55,14 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
+    - name: Build the collection
+      run: |
+        collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
+        echo "::set-env name=COLLECTION_FILE::$collection_file"
+
+    - name: Install the collection
+      run: ansible-galaxy collection install $COLLECTION_FILE
+
     - name: Run tests
       working-directory: ansible_collections/klusters/tls
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -56,11 +56,13 @@ jobs:
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
     - name: Build the collection
+      working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
         echo "::set-env name=COLLECTION_FILE::$collection_file"
 
     - name: Install the collection
+      working-directory: ansible_collections/klusters/tls
       run: ansible-galaxy collection install $COLLECTION_FILE
 
     - name: Run tests

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -55,15 +55,11 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
-    - name: Build the collection
+    - name: Build and Install the collection
       working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-        echo "::set-env name=COLLECTION_FILE::$collection_file"
-
-    - name: Install the collection
-      working-directory: ansible_collections/klusters/tls
-      run: ansible-galaxy collection install $COLLECTION_FILE
+        ansible-galaxy collection install $collection_file
 
     - name: Run tests
       working-directory: ansible_collections/klusters/tls

--- a/.github/workflows/truststores.yml
+++ b/.github/workflows/truststores.yml
@@ -55,6 +55,14 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
+    - name: Build the collection
+      run: |
+        collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
+        echo "::set-env name=COLLECTION_FILE::$collection_file"
+
+    - name: Install the collection
+      run: ansible-galaxy collection install $COLLECTION_FILE
+
     - name: Run tests
       working-directory: ansible_collections/klusters/tls
       run: |

--- a/.github/workflows/truststores.yml
+++ b/.github/workflows/truststores.yml
@@ -56,11 +56,13 @@ jobs:
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
     - name: Build the collection
+      working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
         echo "::set-env name=COLLECTION_FILE::$collection_file"
 
     - name: Install the collection
+      working-directory: ansible_collections/klusters/tls
       run: ansible-galaxy collection install $COLLECTION_FILE
 
     - name: Run tests

--- a/.github/workflows/truststores.yml
+++ b/.github/workflows/truststores.yml
@@ -55,15 +55,11 @@ jobs:
         (test -f molecule/${{ matrix.collection_role }}/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/${{ matrix.collection_role }}/python_requirements.txt ) ||
         (test -f molecule/common/python_requirements.txt && pip install --upgrade --upgrade-strategy eager -r molecule/common/python_requirements.txt )
 
-    - name: Build the collection
+    - name: Build and Install the collection
       working-directory: ansible_collections/klusters/tls
       run: |
         collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-        echo "::set-env name=COLLECTION_FILE::$collection_file"
-
-    - name: Install the collection
-      working-directory: ansible_collections/klusters/tls
-      run: ansible-galaxy collection install $COLLECTION_FILE
+        ansible-galaxy collection install $collection_file
 
     - name: Run tests
       working-directory: ansible_collections/klusters/tls

--- a/roles/encrypt_private_keys/defaults/main.yml
+++ b/roles/encrypt_private_keys/defaults/main.yml
@@ -9,7 +9,4 @@ tls_key_encrypted: '{{ tls_keys_path }}/{{ ansible_fqdn }}_encrypted.key'
 
 tls_key_password: 'default'
 
-install_sys_packages: yes
-install_tls_packages: yes
-
 ...

--- a/roles/keystores/defaults/main.yml
+++ b/roles/keystores/defaults/main.yml
@@ -4,19 +4,17 @@ tls_base_path: /etc/tls/default
 
 tls_certs_path: '{{ tls_base_path }}/certs'
 tls_keys_path: '{{ tls_base_path }}/keys'
-tls_jks_path: '{{ tls_base_path }}/java'
-tls_p12_path: '{{ tls_base_path }}/pkcs12'
+tls_keystore_path: '{{ tls_base_path }}/java'
 
 tls_cert: '{{ tls_certs_path }}/{{ ansible_fqdn }}.cert'
-tls_key: '{{ tls_keys_path }}/{{ ansible_fqdn }}.key'
 tls_key_encrypted: '{{ tls_keys_path }}/{{ ansible_fqdn }}_encrypted.key'
 
-tls_jks_keystore: '{{ tls_jks_path }}/{{ ansible_fqdn }}.jks'
-tls_p12_keystore: '{{ tls_p12_path }}/{{ ansible_fqdn }}.pkcs12'
+tls_keystore_type: jks
+tls_keystore: '{{ tls_keystore_path }}/{{ ansible_fqdn }}.jks'
+tls_keystore_alias: '{{ ansible_fqdn }}'
 
 tls_key_password: 'default'
-tls_jks_keystore_password: 'default'
-tls_p12_password: 'default'
+tls_keystore_password: 'default'
 
 tls_keystore_owner: root
 tls_keystore_group: root

--- a/roles/keystores/tasks/main.yml
+++ b/roles/keystores/tasks/main.yml
@@ -17,31 +17,18 @@
   loop:
   - '{{ tls_certs_path }}'
   - '{{ tls_keys_path }}'
-  - '{{ tls_jks_path }}'
-  - '{{ tls_p12_path }}'
+  - '{{ tls_keystore_path }}'
 
-- name: Generate pkc12 keystore from cert and private_key
-  community.crypto.openssl_pkcs12:
-    action: export
-    path: '{{ tls_p12_keystore }}'
-    passphrase: '{{ tls_p12_password }}'
-    friendly_name: '{{ ansible_fqdn }}'
+- name: Create Java keystore from cert and private_key
+  community.general.java_keystore:
+    name: '{{ tls_keystore_alias }}'
     certificate_path: '{{ tls_cert }}'
-    privatekey_path:  '{{ tls_key_encrypted }}'
-    privatekey_passphrase: '{{ tls_key_password }}'
+    private_key_path: '{{ tls_key_encrypted }}'
+    private_key_passphrase: '{{ tls_key_password }}'
+    password: '{{ tls_keystore_password }}'
+    dest: '{{ tls_keystore }}'
     owner: '{{ tls_keystore_owner }}'
     group: '{{ tls_keystore_group }}'
-    state: present
-
-- name: Import pkcs12 keystore in a java keystore
-  community.general.java_cert:
-    pkcs12_path: '{{ tls_p12_keystore }}'
-    pkcs12_password: '{{ tls_p12_password }}'
-    cert_alias: '{{ ansible_fqdn }}'
-    pkcs12_alias: '{{ ansible_fqdn }}'
-    keystore_path: '{{ tls_jks_keystore }}'
-    keystore_pass: '{{ tls_jks_keystore_password }}'
-    keystore_create: yes
-    state: present
+    keystore_type: jks
 
 ...


### PR DESCRIPTION
community.crypto.openssl_pkcs12 added python dependencies than cannot be met with CentOS 7 systems packages (python-cryptography & pyOpenSSL)
PyOpenSSL >= 0.15 or cryptography >= 3.0

So we moved to community.general.java_keystore instead (based on openssl & keytool)

